### PR TITLE
tests(Makefile): add test-style shellcheck target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,15 @@ IMAGE_PREFIX ?= deis
 
 include versioning.mk
 
+SHELL_SCRIPTS = $(wildcard rootfs/bin/*) $(wildcard rootfs/runner/*) $(wildcard _scripts/*.sh)
+
+# The following variables describe the containerized development environment
+# and other build options
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.11.0
+DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
+DEV_ENV_CMD := docker run --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
+DEV_ENV_CMD_INT := docker run -it --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
+
 all: build docker-build docker-push
 
 bootstrap:
@@ -43,7 +52,15 @@ mc:
 	docker push ${DEIS_REGISTRY}/deis/minio-mc:latest
 	perl -pi -e "s|image: [a-z0-9.:]+\/|image: ${DEIS_REGISTRY}/|g" manifests/deis-mc-pod.yaml
 
-test:
+test: test-style test-unit test-functional
+
+test-unit:
+	@echo "Implement unit tests in _tests directory"
+
+test-functional:
 	@echo "Implement functional tests in _tests directory"
 
-.PHONY: all bootstrap build docker-compile kube-up kube-down deploy mc kube-mc test
+test-style:
+	${DEV_ENV_CMD} shellcheck $(SHELL_SCRIPTS)
+
+.PHONY: all bootstrap build docker-compile kube-up kube-down deploy mc kube-mc test test-style test-unit test-functional

--- a/rootfs/bin/get_object
+++ b/rootfs/bin/get_object
@@ -10,4 +10,4 @@ if [ "$BUILDER_STORAGE" == "minio" ]; then
 elif [ "$BUILDER_STORAGE" == "azure" ]; then
   export CONTAINER_FILE=/var/run/secrets/deis/objectstore/creds/builder-container
 fi
-objstorage --storage-type=$BUILDER_STORAGE download $SLUG_URL $GET_PATH
+objstorage --storage-type="$BUILDER_STORAGE" download "$SLUG_URL" "$GET_PATH"

--- a/rootfs/runner/init
+++ b/rootfs/runner/init
@@ -34,7 +34,8 @@ if [[ -s .release ]]; then
 	ruby -e "require 'yaml';(YAML.load_file('.release')['config_vars'] || {}).each{|k,v| puts \"#{k}='#{v}'\"}" > .profile.d/config_vars
 fi
 for file in .profile.d/*; do
-	source $file
+	# shellcheck source=/dev/null
+	source "$file"
 done
 hash -r
 
@@ -47,8 +48,8 @@ case "$1" in
 			command="$(ruby -e "require 'yaml';puts (YAML.load_file('.release')['default_process_types'] || {})['$2']")"
 		fi
 		;;
-
 	*)
+		# shellcheck disable=SC2124
 		command="$@"
 		;;
 esac
@@ -72,4 +73,4 @@ fi
 
 ## Run!
 
-exec $runner "$command"
+exec "$runner" "$command"


### PR DESCRIPTION
Since slugrunner consists of several `bash` scripts, [`shellcheck`](http://www.shellcheck.net/) can be used to detect common shell programming errors. This adds the standard test Makefile targets ~~and downloads the latest `shellcheck` binary release from S3~~. (v0.4.3 is also the `shellcheck` version installed on Deis Jenkins slaves by the deis-ci-manager ansible playbooks.)

This also fixes the few warnings that linting uncovered, then puts that commit first so that each of these commits passes on its own.

~~(An earlier version of this PR built `shellcheck` from source using Haskell's `cabal`, but that process takes 5-7 minutes, so I extracted the binary artifact Travis CI built and `upx`'ed it for download, which takes Travis one or two seconds to fetch. The entire Travis job took 24 seconds.)~~ This uses docker-go-dev's `shellcheck` now.
