### PR TITLE
fix(.travis.yml): run docker build on all builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - docker
 sudo: required
 script:
-  - make bootstrap test
+  - make bootstrap test build docker-build
 deploy:
   provider: script
   script: _scripts/deploy.sh


### PR DESCRIPTION
I also removed the `make bootstrap` target from .travis.yml since it's a no-op.

Closes #15.
