### PR TITLE
fix(Dockerfile): update objstorage CLI

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -13,7 +13,7 @@ EXPOSE 5000
 
 ADD ./runner /runner
 ADD ./bin /bin
-ADD https://dl.bintray.com/deis/deisci/objstorage-90ca1f4-linux-amd64 /bin/objstorage
+ADD https://dl.bintray.com/deis/deisci/objstorage-7d48b36-linux-amd64 /bin/objstorage
 RUN chmod +x /bin/objstorage
 RUN chown slug:slug /runner/init
 RUN chown slug:slug /bin/get_object


### PR DESCRIPTION
This silences objstorage messages when `DEIS_DEBUG` isn't true. 7d48b36 is the current tip SHA in the object-storage project.

Closes #37.
