### PR TITLE
fix(Dockerfile): download the object storage CLI from GCS

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -13,7 +13,7 @@ EXPOSE 5000
 
 ADD ./runner /runner
 ADD ./bin /bin
-ADD https://dl.bintray.com/deis/deisci/objstorage-7d48b36-linux-amd64 /bin/objstorage
+ADD https://storage.googleapis.com/object-storage-cli/7d48b36/objstorage-7d48b36-linux-amd64 /bin/objstorage
 RUN chmod +x /bin/objstorage
 RUN chown slug:slug /runner/init
 RUN chown slug:slug /bin/get_object


### PR DESCRIPTION
instead of Bintray.

Fixes https://github.com/deis/slugrunner/issues/42
Ref Ref deis/object-storage-cli#15
