### PR TITLE
fix(init): check for valid YAML before accessing hash

### DIFF
--- a/rootfs/runner/init
+++ b/rootfs/runner/init
@@ -31,7 +31,7 @@ mkdir -p .profile.d
 find . -user 1000 -exec chown slug:slug {} \;
 
 if [[ -s .release ]]; then
-	ruby -e "require 'yaml';(YAML.load_file('.release')['config_vars'] || {}).each{|k,v| puts \"#{k}='#{v}'\"}" > .profile.d/config_vars
+	ruby -e "require 'yaml';((YAML.load_file('.release') || {})['config_vars'] || {}).each{|k,v| puts \"#{k}='#{v}'\"}" > .profile.d/config_vars
 fi
 for file in .profile.d/*; do
 	# shellcheck source=/dev/null


### PR DESCRIPTION
Sometimes official buildpacks create a releases file of just `---`. This causes problems when trying to log the default process types in the slugrunner.

See more details in deis/slugbuilder#103
