### PR TITLE
fix(Makefile): ensure to use "latest" build of cedar:14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ bootstrap:
 	@echo Nothing to do.
 
 docker-build:
-	docker build --rm -t ${IMAGE} rootfs
+	docker build --pull --rm -t ${IMAGE} rootfs
 	docker tag ${IMAGE} ${MUTABLE_IMAGE}
 
 deploy: docker-build docker-push kube-pod


### PR DESCRIPTION
Heroku constantly updates the heroku/cedar:14 image as security patches are applied. This change enforces us to pull down the latest version of the image before building the image.

This should help with the security vulnerabilities noticed at https://quay.io/repository/deis/slugrunner/image/be8ee4d86705adf1c520ce18851b4b253219c979eb0e2089566dcd5b87154bd0?tab=vulnerabilities
