### PR TITLE
feat(get_object): use `MINIO_BUCKET` env-var

### DIFF
--- a/rootfs/bin/get_object
+++ b/rootfs/bin/get_object
@@ -4,8 +4,9 @@ GET_PATH=slug.tgz
 
 export BUCKET_FILE=/var/run/secrets/deis/objectstore/creds/builder-bucket
 if [ "$BUILDER_STORAGE" == "minio" ]; then
+  MINIO_BUCKET_NAME=${MINIO_BUCKET:-git}
   mkdir -p /app/objectstore/minio
-  echo "git" > /app/objectstore/minio/builder-bucket
+  echo "$MINIO_BUCKET_NAME" > /app/objectstore/minio/builder-bucket
   export BUCKET_FILE=/app/objectstore/minio/builder-bucket
 elif [ "$BUILDER_STORAGE" == "azure" ] || [ "$BUILDER_STORAGE" == "swift" ]; then
   export CONTAINER_FILE=/var/run/secrets/deis/objectstore/creds/builder-container


### PR DESCRIPTION
Use MINIO_BUCKET environment variable to define the bucket name for minio storage type
instead of hardcoded `git`

If there isnt a value on MINIO_BUCKET var, get_object will use `git` by default